### PR TITLE
rename 'index.js' to 'index.jsx' in the reboost config file of the re…

### DIFF
--- a/packages/create-app/templates/react/reboost.js
+++ b/packages/create-app/templates/react/reboost.js
@@ -8,7 +8,7 @@ const ReactRefreshPlugin = require('@reboost/plugin-react-refresh');
 
 start({
   entries: [
-    ['./src/index.js', './public/dist/index.js']
+    ['./src/index.jsx', './public/dist/index.js']
   ],
   contentServer: {
     root: './public',


### PR DESCRIPTION
I come across with `reboost` by trying to solve [this issue](https://github.com/suren-atoyan/monaco-react/issues/139).

The starter app generated by `npm init @reboost/app` (`react` template) didn't run (npm run dev); the error was:

<img width="362" alt="Screen Shot 2021-01-13 at 17 46 48" src="https://user-images.githubusercontent.com/13118722/104461347-ac737500-55c8-11eb-9f63-1949f6b677b5.png">

It's sensible, because, actually there is no `root/src/index.js` file:

<img width="1058" alt="Screen Shot 2021-01-13 at 17 47 28" src="https://user-images.githubusercontent.com/13118722/104461451-c8771680-55c8-11eb-9b6c-58a590f10659.png">

It should be `root/src/index.jsx`:

<img width="618" alt="Screen Shot 2021-01-13 at 17 50 07" src="https://user-images.githubusercontent.com/13118722/104461541-e8a6d580-55c8-11eb-935e-e74d32bb499e.png">

I did the fix in the `reboost/packages/create-app/templates/react/reboost.js` file (hope it's the right place for that).